### PR TITLE
Add a manager network/cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 terraform.tfvars
 .terraform
+id_rsa
+id_rsa.pub

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,6 +33,7 @@ module "consul" {
   router     = "${openstack_networking_router_v2.router.id}"
   keypair    = "${openstack_compute_keypair_v2.manager.name}"
   management = "${openstack_networking_network_v2.manager.id}"
+  secgroup   = "${openstack_compute_secgroup_v2.manager.name}"
 }
 
 module "web" {
@@ -40,6 +41,7 @@ module "web" {
   router     = "${openstack_networking_router_v2.router.id}"
   keypair    = "${openstack_compute_keypair_v2.manager.name}"
   management = "${openstack_networking_network_v2.manager.id}"
+  secgroup   = "${openstack_compute_secgroup_v2.manager.name}"
 }
 
 module "haproxy" {
@@ -47,4 +49,5 @@ module "haproxy" {
   router     = "${openstack_networking_router_v2.router.id}"
   keypair    = "${openstack_compute_keypair_v2.manager.name}"
   management = "${openstack_networking_network_v2.manager.id}"
+  secgroup   = "${openstack_compute_secgroup_v2.manager.name}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,19 +29,22 @@ resource "openstack_compute_secgroup_v2" "remote" {
 
 # use modules to segregate the project a bit
 module "consul" {
-  source  = "modules/consul"
-  router  = "${openstack_networking_router_v2.router.id}"
-  keypair = "${openstack_compute_keypair_v2.remote.name}"
+  source     = "modules/consul"
+  router     = "${openstack_networking_router_v2.router.id}"
+  keypair    = "${openstack_compute_keypair_v2.manager.name}"
+  management = "${openstack_networking_network_v2.manager.id}"
 }
 
 module "web" {
-  source  = "modules/web"
-  router  = "${openstack_networking_router_v2.router.id}"
-  keypair = "${openstack_compute_keypair_v2.remote.name}"
+  source     = "modules/web"
+  router     = "${openstack_networking_router_v2.router.id}"
+  keypair    = "${openstack_compute_keypair_v2.manager.name}"
+  management = "${openstack_networking_network_v2.manager.id}"
 }
 
 module "haproxy" {
-  source  = "modules/haproxy"
-  router  = "${openstack_networking_router_v2.router.id}"
-  keypair = "${openstack_compute_keypair_v2.remote.name}"
+  source     = "modules/haproxy"
+  router     = "${openstack_networking_router_v2.router.id}"
+  keypair    = "${openstack_compute_keypair_v2.manager.name}"
+  management = "${openstack_networking_network_v2.manager.id}"
 }

--- a/terraform/manager.tf
+++ b/terraform/manager.tf
@@ -1,0 +1,83 @@
+# create a SSH key data type containing locally resourced keys
+data "tls_public_key" "manager" {
+  private_key_pem = "${file("id_rsa")}"
+}
+
+# create a template that runs a script with the SSH keys
+data "template_file" "manager_keys" {
+  template = "${file("templates/add_keys.sh.tpl")}"
+
+  vars {
+    private_key = "${data.tls_public_key.manager.private_key_pem}"
+    public_key  = "${data.tls_public_key.manager.public_key_openssh}"
+  }
+}
+
+# create a cloud-init template using the above script template
+data "template_cloudinit_config" "manager" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    filename     = "add_keys.sh"
+    content_type = "text/x-shellscript"
+    content      = "${data.template_file.manager_keys.rendered}"
+  }
+}
+
+# add the keypair to OpenStack for use in other instances
+resource "openstack_compute_keypair_v2" "manager" {
+  name       = "manager"
+  public_key = "${data.tls_public_key.manager.public_key_openssh}"
+}
+
+# create the internal management network
+resource "openstack_networking_network_v2" "manager" {
+  name           = "manager-net"
+  admin_state_up = "true"
+}
+
+# create a subnet on the internal management network
+resource "openstack_networking_subnet_v2" "manager" {
+  name            = "manager-subnet"
+  network_id      = "${openstack_networking_network_v2.manager.id}"
+  cidr            = "${var.manager_cidr}"
+  ip_version      = 4
+  enable_dhcp     = "true"
+  dns_nameservers = "${var.nameservers}"
+}
+
+# associate the Manager subnet with the main router
+resource "openstack_networking_router_interface_v2" "manager" {
+  router_id = "${openstack_networking_router_v2.router.id}"
+  subnet_id = "${openstack_networking_subnet_v2.manager.id}"
+}
+
+# create the manager instance
+resource "openstack_compute_instance_v2" "manager" {
+  name            = "manager"
+  image_name      = "${var.manager_image}"
+  flavor_name     = "${var.manager_flavor}"
+  key_pair        = "${openstack_compute_keypair_v2.remote.name}"
+  security_groups = ["${openstack_compute_secgroup_v2.remote.name}"]
+
+  network = {
+    uuid = "${openstack_networking_network_v2.manager.id}"
+  }
+
+  user_data = "${data.template_cloudinit_config.manager.rendered}"
+
+  # terraform is not smart enough to realize we need a subnet first
+  depends_on = ["openstack_networking_subnet_v2.manager"]
+}
+
+# appropriate a floating IP for the manager instance
+resource "openstack_networking_floatingip_v2" "manager" {
+  pool = "ntnu-internal"
+}
+
+# associate the floating IP with the manager instance
+resource "openstack_compute_floatingip_associate_v2" "manager" {
+  floating_ip = "${openstack_networking_floatingip_v2.manager.address}"
+  instance_id = "${openstack_compute_instance_v2.manager.0.id}"
+}

--- a/terraform/manager.tf
+++ b/terraform/manager.tf
@@ -81,3 +81,16 @@ resource "openstack_compute_floatingip_associate_v2" "manager" {
   floating_ip = "${openstack_networking_floatingip_v2.manager.address}"
   instance_id = "${openstack_compute_instance_v2.manager.0.id}"
 }
+
+# create security group for internal access
+resource "openstack_compute_secgroup_v2" "manager" {
+  name        = "manager"
+  description = "Internal SSH access"
+
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "192.168.1.0/24"
+  }
+}

--- a/terraform/modules/consul/main.tf
+++ b/terraform/modules/consul/main.tf
@@ -1,10 +1,11 @@
 # create a new Consul instance
 resource "openstack_compute_instance_v2" "consul" {
-  count       = "${var.replicas}"
-  name        = "consul${count.index+1}"
-  image_name  = "${var.image_name}"
-  flavor_name = "${var.flavor_name}"
-  key_pair    = "${var.keypair}"
+  count           = "${var.replicas}"
+  name            = "consul${count.index+1}"
+  image_name      = "${var.image_name}"
+  flavor_name     = "${var.flavor_name}"
+  key_pair        = "${var.keypair}"
+  security_groups = ["${var.secgroup}"]
 
   network = {
     uuid = "${openstack_networking_network_v2.consul.id}"

--- a/terraform/modules/consul/main.tf
+++ b/terraform/modules/consul/main.tf
@@ -11,7 +11,12 @@ resource "openstack_compute_instance_v2" "consul_server" {
     uuid = "${openstack_networking_network_v2.consul_net.id}"
   }
 
-  depends_on = ["openstack_networking_subnet_v2.consul_subnet"]
+  network = {
+    uuid = "${var.management}"
+  }
+
+  # terraform is not smart enough to realize we need a subnet first
+  depends_on = ["openstack_networking_subnet_v2.consul"]
 }
 
 # create the Consul network

--- a/terraform/modules/consul/main.tf
+++ b/terraform/modules/consul/main.tf
@@ -1,5 +1,5 @@
 # create a new Consul instance
-resource "openstack_compute_instance_v2" "consul_server" {
+resource "openstack_compute_instance_v2" "consul" {
   count       = "${var.replicas}"
   name        = "consul${count.index+1}"
   image_name  = "${var.image_name}"
@@ -7,8 +7,7 @@ resource "openstack_compute_instance_v2" "consul_server" {
   key_pair    = "${var.keypair}"
 
   network = {
-    # since this is a dependable, Terraform will create the network before the instance
-    uuid = "${openstack_networking_network_v2.consul_net.id}"
+    uuid = "${openstack_networking_network_v2.consul.id}"
   }
 
   network = {
@@ -20,27 +19,23 @@ resource "openstack_compute_instance_v2" "consul_server" {
 }
 
 # create the Consul network
-resource "openstack_networking_network_v2" "consul_net" {
+resource "openstack_networking_network_v2" "consul" {
   name           = "consul-net"
   admin_state_up = "true"
 }
 
 # create the Consul subnet
-resource "openstack_networking_subnet_v2" "consul_subnet" {
+resource "openstack_networking_subnet_v2" "consul" {
   name            = "consul-subnet"
-  network_id      = "${openstack_networking_network_v2.consul_net.id}"
+  network_id      = "${openstack_networking_network_v2.consul.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   enable_dhcp     = "true"
   dns_nameservers = "${var.nameservers}"
-
-  depends_on = ["openstack_networking_network_v2.consul_net"]
 }
 
 # associate the Consul subnet with the main router
-resource "openstack_networking_router_interface_v2" "consul_router_interface" {
+resource "openstack_networking_router_interface_v2" "consul" {
   router_id = "${var.router}"
-  subnet_id = "${openstack_networking_subnet_v2.consul_subnet.id}"
-
-  depends_on = ["openstack_networking_subnet_v2.consul_subnet"]
+  subnet_id = "${openstack_networking_subnet_v2.consul.id}"
 }

--- a/terraform/modules/consul/variables.tf
+++ b/terraform/modules/consul/variables.tf
@@ -4,12 +4,12 @@ variable "replicas" {
 }
 
 variable "image_name" {
-  description = "Name of image to use for Consul servers"
+  description = "Image name to use for the instances"
   default     = "Ubuntu Server 18.04 LTS (Bionic Beaver) amd64"
 }
 
 variable "flavor_name" {
-  description = "Name of flavor to use for Consul servers"
+  description = "Flavor name to use for the instances"
   default     = "m1.medium"
 }
 
@@ -18,16 +18,20 @@ variable "router" {
 }
 
 variable "subnet_cidr" {
-  description = "The address space for the Consul network"
+  description = "The address space for the network"
   default     = "192.168.100.0/24"
 }
 
 variable "nameservers" {
-  description = "The nameservers used by the Consul network"
+  description = "The nameservers used by the instances"
   type        = "list"
   default     = ["1.1.1.1", "1.0.0.1"]
 }
 
 variable "keypair" {
-  description = "Key pair to allow access into the Consul instances"
+  description = "Key pair to allow access into the instances"
+}
+
+variable "management" {
+  description = "Management network"
 }

--- a/terraform/modules/consul/variables.tf
+++ b/terraform/modules/consul/variables.tf
@@ -35,3 +35,7 @@ variable "keypair" {
 variable "management" {
   description = "Management network"
 }
+
+variable "secgroup" {
+  description = "Default security group to allow"
+}

--- a/terraform/modules/haproxy/main.tf
+++ b/terraform/modules/haproxy/main.tf
@@ -1,5 +1,5 @@
 # create a new haproxy instance
-resource "openstack_compute_instance_v2" "haproxy_server" {
+resource "openstack_compute_instance_v2" "haproxy" {
   count       = "${var.replicas}"
   name        = "haproxy${count.index+1}"
   image_name  = "${var.image_name}"
@@ -8,7 +8,7 @@ resource "openstack_compute_instance_v2" "haproxy_server" {
 
   network = {
     # since this is a dependable, Terraform will create the network before the instance
-    uuid = "${openstack_networking_network_v2.haproxy_net.id}"
+    uuid = "${openstack_networking_network_v2.haproxy.id}"
   }
 
   network = {
@@ -20,27 +20,23 @@ resource "openstack_compute_instance_v2" "haproxy_server" {
 }
 
 # create the haproxy network
-resource "openstack_networking_network_v2" "haproxy_net" {
+resource "openstack_networking_network_v2" "haproxy" {
   name           = "haproxy-net"
   admin_state_up = "true"
 }
 
 # create the haproxy subnet
-resource "openstack_networking_subnet_v2" "haproxy_subnet" {
+resource "openstack_networking_subnet_v2" "haproxy" {
   name            = "haproxy-subnet"
-  network_id      = "${openstack_networking_network_v2.haproxy_net.id}"
+  network_id      = "${openstack_networking_network_v2.haproxy.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   enable_dhcp     = "true"
   dns_nameservers = "${var.nameservers}"
-
-  depends_on = ["openstack_networking_network_v2.haproxy_net"]
 }
 
 # associate the haproxy subnet with the main router
-resource "openstack_networking_router_interface_v2" "haproxy_router_interface" {
+resource "openstack_networking_router_interface_v2" "haproxy" {
   router_id = "${var.router}"
-  subnet_id = "${openstack_networking_subnet_v2.haproxy_subnet.id}"
-
-  depends_on = ["openstack_networking_subnet_v2.haproxy_subnet"]
+  subnet_id = "${openstack_networking_subnet_v2.haproxy.id}"
 }

--- a/terraform/modules/haproxy/main.tf
+++ b/terraform/modules/haproxy/main.tf
@@ -1,10 +1,11 @@
 # create a new haproxy instance
 resource "openstack_compute_instance_v2" "haproxy" {
-  count       = "${var.replicas}"
-  name        = "haproxy${count.index+1}"
-  image_name  = "${var.image_name}"
-  flavor_name = "${var.flavor_name}"
-  key_pair    = "${var.keypair}"
+  count           = "${var.replicas}"
+  name            = "haproxy${count.index+1}"
+  image_name      = "${var.image_name}"
+  flavor_name     = "${var.flavor_name}"
+  key_pair        = "${var.keypair}"
+  security_groups = ["${var.secgroup}"]
 
   network = {
     # since this is a dependable, Terraform will create the network before the instance

--- a/terraform/modules/haproxy/main.tf
+++ b/terraform/modules/haproxy/main.tf
@@ -11,7 +11,12 @@ resource "openstack_compute_instance_v2" "haproxy_server" {
     uuid = "${openstack_networking_network_v2.haproxy_net.id}"
   }
 
-  depends_on = ["openstack_networking_subnet_v2.haproxy_subnet"]
+  network = {
+    uuid = "${var.management}"
+  }
+
+  # terraform is not smart enough to realize we need a subnet first
+  depends_on = ["openstack_networking_subnet_v2.haproxy"]
 }
 
 # create the haproxy network

--- a/terraform/modules/haproxy/variables.tf
+++ b/terraform/modules/haproxy/variables.tf
@@ -4,12 +4,12 @@ variable "replicas" {
 }
 
 variable "image_name" {
-  description = "Name of image to use for Consul servers"
+  description = "Image name to use for the instances"
   default     = "Ubuntu Server 18.04 LTS (Bionic Beaver) amd64"
 }
 
 variable "flavor_name" {
-  description = "Name of flavor to use for Consul servers"
+  description = "Flavor name to use for the instances"
   default     = "m1.medium"
 }
 
@@ -18,16 +18,20 @@ variable "router" {
 }
 
 variable "subnet_cidr" {
-  description = "The address space for the Consul network"
+  description = "The address space for the network"
   default     = "192.168.120.0/24"
 }
 
 variable "nameservers" {
-  description = "The nameservers used by the Consul network"
+  description = "The nameservers used by the instances"
   type        = "list"
   default     = ["1.1.1.1", "1.0.0.1"]
 }
 
 variable "keypair" {
-  description = "Key pair to allow access into the Consul instances"
+  description = "Key pair to allow access into the instances"
+}
+
+variable "management" {
+  description = "Management network"
 }

--- a/terraform/modules/haproxy/variables.tf
+++ b/terraform/modules/haproxy/variables.tf
@@ -35,3 +35,7 @@ variable "keypair" {
 variable "management" {
   description = "Management network"
 }
+
+variable "secgroup" {
+  description = "Default security group to allow"
+}

--- a/terraform/modules/web/main.tf
+++ b/terraform/modules/web/main.tf
@@ -1,5 +1,5 @@
 # create a new web instance
-resource "openstack_compute_instance_v2" "web_server" {
+resource "openstack_compute_instance_v2" "web" {
   count       = "${var.replicas}"
   name        = "web${count.index+1}"
   image_name  = "${var.image_name}"
@@ -7,8 +7,7 @@ resource "openstack_compute_instance_v2" "web_server" {
   key_pair    = "${var.keypair}"
 
   network = {
-    # since this is a dependable, Terraform will create the network before the instance
-    uuid = "${openstack_networking_network_v2.web_net.id}"
+    uuid = "${openstack_networking_network_v2.web.id}"
   }
 
   network = {
@@ -20,27 +19,23 @@ resource "openstack_compute_instance_v2" "web_server" {
 }
 
 # create the web network
-resource "openstack_networking_network_v2" "web_net" {
+resource "openstack_networking_network_v2" "web" {
   name           = "web-net"
   admin_state_up = "true"
 }
 
 # create the web subnet
-resource "openstack_networking_subnet_v2" "web_subnet" {
+resource "openstack_networking_subnet_v2" "web" {
   name            = "web-subnet"
-  network_id      = "${openstack_networking_network_v2.web_net.id}"
+  network_id      = "${openstack_networking_network_v2.web.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   enable_dhcp     = "true"
   dns_nameservers = "${var.nameservers}"
-
-  depends_on = ["openstack_networking_network_v2.web_net"]
 }
 
 # associate the web subnet with the main router
-resource "openstack_networking_router_interface_v2" "web_router_interface" {
+resource "openstack_networking_router_interface_v2" "web" {
   router_id = "${var.router}"
-  subnet_id = "${openstack_networking_subnet_v2.web_subnet.id}"
-
-  depends_on = ["openstack_networking_subnet_v2.web_subnet"]
+  subnet_id = "${openstack_networking_subnet_v2.web.id}"
 }

--- a/terraform/modules/web/main.tf
+++ b/terraform/modules/web/main.tf
@@ -11,7 +11,12 @@ resource "openstack_compute_instance_v2" "web_server" {
     uuid = "${openstack_networking_network_v2.web_net.id}"
   }
 
-  depends_on = ["openstack_networking_subnet_v2.web_subnet"]
+  network = {
+    uuid = "${var.management}"
+  }
+
+  # terraform is not smart enough to realize we need a subnet first
+  depends_on = ["openstack_networking_subnet_v2.web"]
 }
 
 # create the web network

--- a/terraform/modules/web/main.tf
+++ b/terraform/modules/web/main.tf
@@ -1,10 +1,11 @@
 # create a new web instance
 resource "openstack_compute_instance_v2" "web" {
-  count       = "${var.replicas}"
-  name        = "web${count.index+1}"
-  image_name  = "${var.image_name}"
-  flavor_name = "${var.flavor_name}"
-  key_pair    = "${var.keypair}"
+  count           = "${var.replicas}"
+  name            = "web${count.index+1}"
+  image_name      = "${var.image_name}"
+  flavor_name     = "${var.flavor_name}"
+  key_pair        = "${var.keypair}"
+  security_groups = ["${var.secgroup}"]
 
   network = {
     uuid = "${openstack_networking_network_v2.web.id}"

--- a/terraform/modules/web/variables.tf
+++ b/terraform/modules/web/variables.tf
@@ -35,3 +35,7 @@ variable "keypair" {
 variable "management" {
   description = "Management network"
 }
+
+variable "secgroup" {
+  description = "Default security group to allow"
+}

--- a/terraform/modules/web/variables.tf
+++ b/terraform/modules/web/variables.tf
@@ -4,12 +4,12 @@ variable "replicas" {
 }
 
 variable "image_name" {
-  description = "Name of image to use for Web servers"
+  description = "Image name to use for the instances"
   default     = "Ubuntu Server 18.04 LTS (Bionic Beaver) amd64"
 }
 
 variable "flavor_name" {
-  description = "Name of flavor to use for Web servers"
+  description = "Flavor name to use for the instances"
   default     = "m1.medium"
 }
 
@@ -18,16 +18,20 @@ variable "router" {
 }
 
 variable "subnet_cidr" {
-  description = "The address space for the Web network"
+  description = "The address space for the network"
   default     = "192.168.110.0/24"
 }
 
 variable "nameservers" {
-  description = "The nameservers used by the Web network"
+  description = "The nameservers used by the instances"
   type        = "list"
   default     = ["1.1.1.1", "1.0.0.1"]
 }
 
 variable "keypair" {
-  description = "Key pair to allow access into the Web instances"
+  description = "Key pair to allow access into the instances"
+}
+
+variable "management" {
+  description = "Management network"
 }

--- a/terraform/templates/add_keys.sh.tpl
+++ b/terraform/templates/add_keys.sh.tpl
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# add the keys
+echo -n "${private_key}" > /home/ubuntu/.ssh/id_rsa
+echo -n "${public_key}" > /home/ubuntu/.ssh/id_rsa.pub
+
+# update permissions
+chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa*
+chmod 0600 /home/ubuntu/.ssh/id_rsa*

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,30 @@
 variable "os_keypair" {
-  description = "Public key pair used to access the OpenStack instances."
+  description = "Public key pair used to access the manager instances."
 }
 
 variable "os_external_network" {
   description = "Network ID to attach the router to"
+}
+
+# manager
+variable "manager_cidr" {
+  description = "Internal management network CIDR"
+  default     = "192.168.1.0/24"
+}
+
+variable "manager_image" {
+  description = "Image used for the manager instance(s)"
+  default     = "Ubuntu Server 18.04 LTS (Bionic Beaver) amd64"
+}
+
+variable "manager_flavor" {
+  description = "Flavor used for the manager instance(s)"
+  default     = "m1.micro"
+}
+
+# global
+variable "nameservers" {
+  description = "The nameservers used by all instances"
+  type        = "list"
+  default     = ["1.1.1.1", "1.0.0.1"]
 }


### PR DESCRIPTION
This creates an internal network for management purposes, with a single "manager" instance.
All other instances on the network can be remotely accessed from this management network, without having to expose themselves outside the internal network(s).

Also a little cleanup :lipstick: 